### PR TITLE
uBO: HWzone: Defuse anti-adblock measures

### DIFF
--- a/EasyListHebrew-uBO.txt
+++ b/EasyListHebrew-uBO.txt
@@ -281,6 +281,9 @@ jmusic.me##+js(nostif, mdpDeBlocker)
 ! * Koozi * !
 !koozi.info##.tien-ads-video > div#player:style(visibility: visible!important;)
 !koozi.info##.tien-ads-video:style(background: none!important;)
+| * HWzone * |
+hwzone.co.il###rb-checktag:remove()
+hwzone.co.il##+js(no-fetch-if, adsbygoogle)
 !
 ! * Generic cosmetic filters * !
 ###bthn


### PR DESCRIPTION
HWzone uses 2 measures for adblock detection:
- An element (`#rb-checktag`) containing an ad. If it exists, and is hidden - adblock is detected. Fixed by removing it completely.
- A request to `pagead2.googlesyndication.com/pagead/js/adsbygoogle.js`. If it raises an error - adblock is detected. Fixed by defusing the `fetch` call.